### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ OS X, Linux and Windows:
 ```sh
 git clone https://github.com/idiidk/kahoot-tools.git
 cd kahoot-tools
+npm install
 npm run build
 node kahoot-tools.js
 ```


### PR DESCRIPTION
The installation instructions missed the `npm install` command which is required to build and run the code.